### PR TITLE
Syntactic sugar for literal array calls

### DIFF
--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -110,14 +110,21 @@ IdentTerm: ast::Ident = IDENT => ast::Ident(<>.into());
 Ident: Expr = IdentTerm => Expr::Ident(<>);
 
 Call: Expr = Call_ => Expr::Call(<>);
+Call_: ast::Call = { SimpleCall_, ExprCall_, PipeCall_, LitArrCall_ };
 SimpleCall: Expr = SimpleCall_ => Expr::Call(<>);
+LitArrCall: Expr = LitArrCall_ => Expr::Call(<>);
 
-Call_: ast::Call = { SimpleCall_, ExprCall_, PipeCall_ };
+// A call with a simple Ident as the function, e.g. foo(123)
 SimpleCall_: ast::Call = <func:Ident> <args:Paren<List0<Expr, ",">>> => ast::Call { func: func.into(), args };
+
+// A call with an expression as the function, e.g. foo(1)(2) or {|a| a+1}(2)
 ExprCall_: ast::Call = <func:ExprCallFunc> <args:Paren<List0<Expr, ",">>> => ast::Call { func: func.into(), args };
 ExprCallFunc: Expr = { WrapExpr, Call, ArrayAccess };
 
-// Pipe call: `$first_arg | func($extra_args...)` -> `func($first_arg, $extra_args...)`
+// A call with a literal array as a single argument, e.g. tx [ "version": 2, ... ]
+LitArrCall_: ast::Call = <func:Ident> <arg:ArraySquare> =>  ast::Call { func: func.into(), args: vec![ arg ] };
+
+// Pipe call, e.g. `$first_arg | func($extra_args...)` -> `func($first_arg, $extra_args...)`
 PipeCall_: ast::Call = <first_arg:PipeCallLHS> "|" <func:PipeCallFunc> <extra_args:Paren<List0<Expr, ",">>> =>
   ast::Call { func: func.into(), args: prepend(extra_args, first_arg) };
 PipeCallLHS = { SExpr, ArrayAccess, Duration };
@@ -154,7 +161,7 @@ ArrayCurly: Expr = "{" <e1:Expr> "," <e2:Expr> "}" =>
 
 ArrayAccess_: Expr = <array:ArrayAccessLHS> "." <index:ArrayAccessRHS> =>
   ast::ArrayAccess { array: array.into(), index: index.into() }.into();
-ArrayAccessLHS = { Ident, SimpleCall, Array, BlockExpr, Bytes, ArrayAccess };
+ArrayAccessLHS = { Ident, SimpleCall, BlockExpr, Bytes, ArrayAccess }; // would be nice to have: Array, Paren<Expr>
 ArrayAccessRHS = { Int, Ident, Paren<Expr>, BlockExpr };
 
 // Hack :<
@@ -218,7 +225,7 @@ ChildDeriveWildcard = { "/*", "/ *" };
 ScriptFrag: Expr = "`" <fragments:ScriptFragPart*> "`" => ast::ScriptFrag { fragments }.into();
 ScriptFragPart = { ScriptFragPart_, ScriptFragPart_Infix };
 ScriptFragPart_ = {
-  Ident, Number, String, Bytes, PubKey, DateTime, SimpleCall, ArrayAccess, Array,
+  Ident, Number, String, Bytes, PubKey, DateTime, SimpleCall, LitArrCall, ArrayAccess,
   ScriptFragPart_Mark, BlockExpr, "<" <SimpleExpr> ">", "<" <Duration> ">",
 };
 // Cannot allow all Infix operators because < > conflicts


### PR DESCRIPTION
Syntactic sugar for function calls with a single literal array argument. For example, `foo[1,2,3]` desugars into `foo([1,2,3])`.

Primarily useful for tagged array constructors:

```hack
psbt [
  "unsigned_tx": tx [
    "version": 2,
    ...
  ],
  "inputs": ...
]
```