### PR TITLE
Implement PSBT support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,8 +59,6 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 [[package]]
 name = "bitcoin"
 version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32",
  "bitcoin-internals",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,8 @@ crate-type = ["cdylib", "lib"]
 lto = true
 # webpack fail wasm compilation without this
 opt-level = "s"
+
+# Needed for https://github.com/rust-bitcoin/rust-bitcoin/pull/2850
+[patch.crates-io.bitcoin]
+git = "https://github.com/shesek/rust-bitcoin"
+rev = "ca27d93c712441762f97edccd1045ad08202ab72" # 202406-getkey-vec-v0.31.2

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::result::Result as StdResult;
 
-use miniscript::bitcoin::{
+use bitcoin::{
     self, amount, bip32, hashes, hex, key, network, script, taproot, witness_program,
 };
 use miniscript::policy::compiler::CompilerError;
@@ -268,6 +268,9 @@ pub enum RuntimeError {
 
     #[error("PSBT finalization errors: {}", .0.into_iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
     PsbtFinalize(Vec<miniscript::psbt::Error>),
+
+    #[error("PSBT signing errors: {}", .0.into_iter().map(|(i, e)| format!("input #{}: {}", i, e)).collect::<Vec<_>>().join(", "))]
+    PsbtSigning(bitcoin::psbt::SigningErrors),
 
     #[error("Missing \"input\" field to construct the PSBT transaction input")]
     PsbtAddInMissingTxIn,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,6 @@
 use std::result::Result as StdResult;
 
-use bitcoin::{
-    self, amount, bip32, hashes, hex, key, network, script, taproot, witness_program,
-};
+use bitcoin::{self, amount, bip32, hashes, hex, key, network, script, taproot, witness_program};
 use miniscript::policy::compiler::CompilerError;
 use miniscript::{descriptor, TranslateErr};
 
@@ -104,7 +102,9 @@ pub enum RuntimeError {
     #[error("Expected a transaction as object, raw bytes or tagged list, not {0:?}")]
     NotTxLike(Box<Value>),
 
-    #[error("Expected a bip32 fingerprint as bytes or key, not {0:?}")]
+    #[error(
+        "Expected a 4 bytes BIP32 fingerprint or a key to compute the fingerprint for, not {0:?}"
+    )]
     NotFingerprintLike(Box<Value>),
 
     #[error("Expected raw Script or Bytes, not {0:?}. Perhaps you meant to use explicitScript()/scriptPubKey()?")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -360,6 +360,9 @@ pub enum RuntimeError {
 
     #[error("Failed parsing taproot signature: {0}")]
     SigFromSlice(#[from] bitcoin::taproot::SigFromSliceError),
+
+    #[error("PSBT SigHash error: {0}")]
+    PsbtSigHash(#[from] miniscript::psbt::SighashError),
 }
 
 impl From<TranslateErr<RuntimeError>> for RuntimeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -269,6 +269,12 @@ pub enum RuntimeError {
     #[error("PSBT finalization errors: {}", .0.into_iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
     PsbtFinalize(Vec<miniscript::psbt::Error>),
 
+    #[error("Missing \"input\" field to construct the PSBT transaction input")]
+    PsbtAddInMissingTxIn,
+
+    #[error("Missing \"output\" field to construct the PSBT transaction output")]
+    PsbtAddOutMissingTxOut,
+
     // Generic error raised from user-land Minsc code
     #[error("Exception: {0}")]
     ScriptException(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -349,9 +349,6 @@ pub enum RuntimeError {
     #[error("ECDSA error: {0}")]
     Ecdsa(#[from] bitcoin::ecdsa::Error),
 
-    #[error("PSBT error: {0}")]
-    Psbt(#[from] bitcoin::psbt::Error),
-
     #[error("Failed extracting PSBT tx: {0}")]
     PsbtExtractTx(#[from] bitcoin::psbt::ExtractTxError),
 
@@ -360,6 +357,12 @@ pub enum RuntimeError {
 
     #[error("Failed parsing taproot signature: {0}")]
     SigFromSlice(#[from] bitcoin::taproot::SigFromSliceError),
+
+    #[error("PSBT error: {0}")]
+    Psbt(#[from] bitcoin::psbt::Error),
+
+    #[error("Miniscript PSBT error: {0}")]
+    MiniscriptPsbt(#[from] miniscript::psbt::Error),
 
     #[error("PSBT SigHash error: {0}")]
     PsbtSigHash(#[from] miniscript::psbt::SighashError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -369,6 +369,9 @@ pub enum RuntimeError {
 
     #[error("PSBT SigHash error: {0}")]
     PsbtSigHash(#[from] miniscript::psbt::SighashError),
+
+    #[error("PSBT update error: {0}")]
+    PsbtUtxoUpdate(#[from] miniscript::psbt::UtxoUpdateError),
 }
 
 impl From<TranslateErr<RuntimeError>> for RuntimeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -267,7 +267,7 @@ pub enum RuntimeError {
     PsbtOutputNotFound(usize),
 
     #[error("PSBT finalization errors: {}", .0.into_iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
-    PsbtFinalizeErrors(Vec<miniscript::psbt::Error>),
+    PsbtFinalize(Vec<miniscript::psbt::Error>),
 
     // Generic error raised from user-land Minsc code
     #[error("Exception: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,9 @@ pub enum RuntimeError {
     #[error("Expected a transaction as object, raw bytes or tagged list, not {0:?}")]
     NotTxLike(Box<Value>),
 
+    #[error("Expected a bip32 fingerprint as bytes or key, not {0:?}")]
+    NotFingerprintLike(Box<Value>),
+
     #[error("Expected raw Script or Bytes, not {0:?}. Perhaps you meant to use explicitScript()/scriptPubKey()?")]
     InvalidScriptConstructor(Box<Value>),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -266,6 +266,9 @@ pub enum RuntimeError {
     #[error("PSBT output #{0} does not exists")]
     PsbtOutputNotFound(usize),
 
+    #[error("PSBT finalization errors: {}", .0.into_iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
+    PsbtFinalizeErrors(Vec<miniscript::psbt::Error>),
+
     // Generic error raised from user-land Minsc code
     #[error("Exception: {0}")]
     ScriptException(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -317,6 +317,12 @@ pub enum RuntimeError {
 
     #[error("ECDSA error: {0}")]
     Ecdsa(#[from] bitcoin::ecdsa::Error),
+
+    #[error("PSBT error: {0}")]
+    Psbt(#[from] bitcoin::psbt::Error),
+
+    #[error("Failed extracting PSBT tx: {0}")]
+    PsbtExtractTx(#[from] bitcoin::psbt::ExtractTxError),
 }
 
 impl From<TranslateErr<RuntimeError>> for RuntimeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use miniscript::{descriptor, policy};
 
 pub type PolicyDpk = policy::concrete::Policy<descriptor::DescriptorPublicKey>;
 pub type DescriptorDpk = descriptor::Descriptor<descriptor::DescriptorPublicKey>;
+pub type DescriptorDef = descriptor::Descriptor<descriptor::DefiniteDescriptorKey>;
 pub type MiniscriptDpk<Ctx> = miniscript::Miniscript<descriptor::DescriptorPublicKey, Ctx>;
 
 /// Evaluate the given expression in the default global scope

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -192,8 +192,8 @@ fn should_use_colon_syntax(elements: &Vec<Value>) -> bool {
             // Otherwise, only if the LHS and RHS are of different types
             (
                 lhs @ (Bool(_) | Number(_) | Bytes(_) | Address(_) | PubKey(_) | SecKey(_)
-                | Policy(_) | Descriptor(_) | TapInfo(_) | WithProb(..) | Network(_)
-                | Symbol(_)),
+                | Policy(_) | Descriptor(_) | TapInfo(_) | Psbt(_) | WithProb(..)
+                | Network(_) | Symbol(_)),
                 rhs,
             ) => mem::discriminant(lhs) != mem::discriminant(rhs),
         }
@@ -208,7 +208,8 @@ fn colon_separator(elements: &Vec<Value>) -> &str {
     // Assumes `elements` was already checked to be a 2-tuple
     match (&elements[0], &elements[1]) {
         (
-            String(_) | PubKey(_) | SecKey(_) | Policy(_) | Script(_) | Descriptor(_) | TapInfo(_),
+            String(_) | PubKey(_) | SecKey(_) | Policy(_) | Script(_) | Descriptor(_) | TapInfo(_)
+            | Psbt(_),
             _,
         ) => ": ",
         (_, Array(_)) => ": ",

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -118,6 +118,23 @@ impl IntoIterator for Array {
     }
 }
 
+// Generic conversion from 1/2/3-tuples of any convertible type into an Array
+impl<A: Into<Value>> From<(A,)> for Array {
+    fn from((a,): (A,)) -> Self {
+        Array(vec![a.into()])
+    }
+}
+impl<A: Into<Value>, B: Into<Value>> From<(A, B)> for Array {
+    fn from((a, b): (A, B)) -> Self {
+        Array(vec![a.into(), b.into()])
+    }
+}
+impl<A: Into<Value>, B: Into<Value>, C: Into<Value>> From<(A, B, C)> for Array {
+    fn from((a, b, c): (A, B, C)) -> Self {
+        Array(vec![a.into(), b.into(), c.into()])
+    }
+}
+
 // Generic conversion from Array into a Vec of any convertible type
 impl<T: FromValue> TryFrom<Array> for Vec<T> {
     type Error = Error;

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::{fmt, mem, ops, vec};
 
@@ -122,6 +123,36 @@ impl<T: FromValue> TryFrom<Array> for Vec<T> {
     type Error = Error;
     fn try_from(arr: Array) -> Result<Vec<T>> {
         arr.into_iter().collect_into()
+    }
+}
+
+// Generic conversion from Array into a HashSet of any convertible type
+impl<T: FromValue + std::hash::Hash + Eq> TryFrom<Array> for HashSet<T> {
+    type Error = Error;
+    fn try_from(arr: Array) -> Result<HashSet<T>> {
+        arr.into_iter().map(T::from_value).collect()
+    }
+}
+// Generic conversion from a tagged Array into a HashMap of any convertible key/val
+impl<K: FromValue + std::hash::Hash + Eq, V: FromValue> TryFrom<Array> for HashMap<K, V> {
+    type Error = Error;
+    fn try_from(arr: Array) -> Result<HashMap<K, V>> {
+        arr.into_iter().map(<(K, V)>::from_value).collect()
+    }
+}
+
+// Generic conversion from Array into a BTreeSet of any convertible type
+impl<T: FromValue + Eq + Ord> TryFrom<Array> for BTreeSet<T> {
+    type Error = Error;
+    fn try_from(arr: Array) -> Result<BTreeSet<T>> {
+        arr.into_iter().map(T::from_value).collect()
+    }
+}
+// Generic conversion from a tagged Array into a BTreeMap of any convertible key/val
+impl<K: FromValue + Ord, V: FromValue> TryFrom<Array> for BTreeMap<K, V> {
+    type Error = Error;
+    fn try_from(arr: Array) -> Result<BTreeMap<K, V>> {
+        arr.into_iter().map(<(K, V)>::from_value).collect()
     }
 }
 

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -395,6 +395,15 @@ impl Value {
     pub fn array(elements: Vec<Value>) -> Self {
         Value::Array(Array(elements))
     }
+    pub fn arr1(a: impl Into<Value>) -> Value {
+        Self::array(vec![a.into()])
+    }
+    pub fn arr2(a: impl Into<Value>, b: impl Into<Value>) -> Value {
+        Self::array(vec![a.into(), b.into()])
+    }
+    pub fn arr3(a: impl Into<Value>, b: impl Into<Value>, c: impl Into<Value>) -> Value {
+        Self::array(vec![a.into(), b.into(), c.into()])
+    }
 }
 
 // Parse & evaluate the string code in the default global scope to produce a Value

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -236,6 +236,8 @@ impl_hash_conv!(hashes::sha256::Hash);
 impl_hash_conv!(hashes::sha256d::Hash);
 impl_hash_conv!(hashes::ripemd160::Hash);
 impl_hash_conv!(hashes::hash160::Hash);
+impl_hash_conv!(bitcoin::TapNodeHash);
+impl_hash_conv!(bitcoin::TapLeafHash);
 impl_hash_conv!(miniscript::hash256::Hash);
 
 /// Generic conversion from a Value/Option<Value> into T/Option<T> of any TryFrom<Value> type.
@@ -357,6 +359,11 @@ impl Value {
     }
     pub fn is_empty_array(&self) -> bool {
         matches!(self, Value::Array(arr) if arr.is_empty())
+    }
+
+    pub fn into_u8(self) -> Result<u8> {
+        // Cannot be implemented as TryFrom because the Vec<u8> and Vec<T> conversions would conflict
+        Ok(self.into_u32()?.try_into()?)
     }
 
     pub fn into_f64(self) -> Result<f64> {

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -74,6 +74,11 @@ impl From<f64> for Value {
         Number::Float(n).into()
     }
 }
+impl From<u8> for Value {
+    fn from(num: u8) -> Value {
+        Number::Int(num.into()).into()
+    }
+}
 impl From<usize> for Value {
     fn from(num: usize) -> Value {
         // TODO this should use TryFrom
@@ -400,6 +405,9 @@ impl Value {
 
     pub fn array(elements: Vec<Value>) -> Self {
         Value::Array(Array(elements))
+    }
+    pub fn array_of(array: impl Into<Array>) -> Self {
+        Value::Array(array.into())
     }
     pub fn arr1(a: impl Into<Value>) -> Value {
         Self::array(vec![a.into()])

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -80,6 +80,12 @@ impl From<usize> for Value {
         Number::Int(num.try_into().unwrap()).into()
     }
 }
+impl TryFrom<u64> for Value {
+    type Error = Error;
+    fn try_from(num: u64) -> Result<Self> {
+        Ok(Value::Number(Number::Int(num.try_into()?)))
+    }
+}
 
 // From NativeFunction/UserFunction to Value
 impl<T: Into<Function>> From<T> for Value {

--- a/src/stdlib/btc.rs
+++ b/src/stdlib/btc.rs
@@ -15,6 +15,7 @@ use miniscript::descriptor::{
     self, Descriptor, DescriptorPublicKey, DescriptorSecretKey, DescriptorXKey, SinglePriv,
     SinglePub, SinglePubKey,
 };
+use miniscript::psbt::PsbtExt;
 
 use super::script_marker::{Marker, MarkerItem, ScriptMarker};
 use crate::runtime::scope::{Mutable, ScopeRef};
@@ -530,7 +531,7 @@ impl TryFrom<Value> for Transaction {
         Ok(match value {
             Value::Transaction(tx) => tx,
             Value::Bytes(bytes) => bitcoin::consensus::deserialize(&bytes)?,
-            Value::Psbt(psbt) => psbt.extract_tx()?,
+            Value::Psbt(psbt) => psbt.extract(&EC)?,
 
             // From tagged [ "version": $version, "locktime": $locktime, "inputs": [ .. ], "outputs": [ .. ] ]
             Value::Array(_) => {

--- a/src/stdlib/btc.rs
+++ b/src/stdlib/btc.rs
@@ -361,16 +361,25 @@ impl Value {
 // Convert from Bitcoin types to Value
 
 impl From<XOnlyPublicKey> for Value {
-    fn from(key: XOnlyPublicKey) -> Self {
+    fn from(pk: XOnlyPublicKey) -> Self {
         Value::PubKey(DescriptorPublicKey::Single(SinglePub {
-            key: SinglePubKey::XOnly(key),
+            key: SinglePubKey::XOnly(pk),
             origin: None,
         }))
     }
 }
 impl From<TweakedPublicKey> for Value {
-    fn from(key: TweakedPublicKey) -> Self {
-        key.to_inner().into()
+    fn from(pk: TweakedPublicKey) -> Self {
+        pk.to_inner().into()
+    }
+}
+
+impl From<bitcoin::PublicKey> for Value {
+    fn from(pk: bitcoin::PublicKey) -> Self {
+        Value::PubKey(DescriptorPublicKey::Single(SinglePub {
+            key: SinglePubKey::FullKey(pk),
+            origin: None,
+        }))
     }
 }
 

--- a/src/stdlib/btc.rs
+++ b/src/stdlib/btc.rs
@@ -524,6 +524,7 @@ impl TryFrom<Value> for Transaction {
         Ok(match value {
             Value::Transaction(tx) => tx,
             Value::Bytes(bytes) => bitcoin::consensus::deserialize(&bytes)?,
+            Value::Psbt(psbt) => psbt.extract_tx()?,
 
             // From tagged [ "version": $version, "locktime": $locktime, "inputs": [ .. ], "outputs": [ .. ] ]
             Value::Array(_) => {

--- a/src/stdlib/miniscript.rs
+++ b/src/stdlib/miniscript.rs
@@ -243,6 +243,12 @@ impl TryFrom<Value> for Descriptor {
         }
     }
 }
+impl TryFrom<Value> for miniscript::Descriptor<miniscript::DefiniteDescriptorKey> {
+    type Error = Error;
+    fn try_from(value: Value) -> Result<Self> {
+        Ok(Descriptor::try_from(value)?.at_derivation_index(0)?)
+    }
+}
 impl<Ctx: ScriptContext> TryFrom<Value> for Miniscript<Ctx> {
     type Error = Error;
     fn try_from(value: Value) -> Result<Self> {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -9,6 +9,7 @@ use crate::{time, Library};
 pub mod btc;
 pub mod ctv;
 pub mod miniscript;
+pub mod psbt;
 pub mod script_marker;
 pub mod tagged;
 pub mod taproot;
@@ -57,16 +58,10 @@ pub fn attach_stdlib(scope: &ScopeRef<Mutable>) {
         scope.set("MIN_NUMBER", i64::MIN).unwrap();
     }
 
-    // Bitcoin related functions
     self::btc::attach_stdlib(scope);
-
-    // Miniscript related functions
     self::miniscript::attach_stdlib(scope);
-
-    // Taproot related functions
     self::taproot::attach_stdlib(scope);
-
-    // CTV
+    self::psbt::attach_stdlib(scope);
     self::ctv::attach_stdlib(scope);
 
     // Standard library implemented in Minsc

--- a/src/stdlib/psbt.rs
+++ b/src/stdlib/psbt.rs
@@ -17,6 +17,7 @@ pub fn attach_stdlib(scope: &ScopeRef<Mutable>) {
     scope.set_fn("psbt::update", fns::update).unwrap();
     scope.set_fn("psbt::combine", fns::combine).unwrap();
     scope.set_fn("psbt::sighash", fns::sighash).unwrap();
+    scope.set_fn("psbt::fee", fns::fee).unwrap();
 }
 
 impl TryFrom<Value> for Psbt {
@@ -69,6 +70,11 @@ pub mod fns {
 
         let sighash_msg = psbt.sighash_msg(input_index, &mut sighash_cache, tapleaf_hash)?;
         Ok(sighash_msg.to_secp_msg()[..].to_vec().into())
+    }
+
+    /// psbt::fee(Psbt) -> Int
+    pub fn fee(args: Array, _: &ScopeRef) -> Result<Value> {
+        Ok(args.arg_into::<Psbt>()?.fee()?.to_sat().try_into()?)
     }
 }
 

--- a/src/stdlib/psbt.rs
+++ b/src/stdlib/psbt.rs
@@ -72,7 +72,7 @@ pub mod fns {
             Ok(()) => vec![],
             Err(errors) => errors.iter().map(|e| Value::from(e.to_string())).collect(),
         };
-        Ok(Value::arr2(psbt, errors))
+        Ok(Value::array_of((psbt, errors)))
     }
 
     /// psbt::extract(Psbt, Bool finalize=false) -> Transaction

--- a/src/stdlib/psbt.rs
+++ b/src/stdlib/psbt.rs
@@ -4,7 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv};
 use bitcoin::psbt::{self, Psbt};
 use bitcoin::{secp256k1, PrivateKey, PublicKey, TxIn, TxOut};
-use miniscript::psbt::PsbtExt;
+use miniscript::psbt::{PsbtExt, PsbtInputExt, PsbtOutputExt};
 
 use crate::error::ResultExt;
 use crate::runtime::{Array, Error, FromValue, Mutable, Number::Int, Result, ScopeRef, Value};
@@ -263,6 +263,9 @@ fn update_input(psbt_input: &mut psbt::Input, tags: Array) -> Result<()> {
             "tap_merkle_root" => psbt_input.tap_merkle_root = Some(val.try_into()?),
             "proprietary" => psbt_input.proprietary = val.try_into()?,
             "unknown" => psbt_input.unknown = val.try_into()?,
+            "descriptor" => psbt_input
+                .update_with_descriptor_unchecked(&val.try_into()?)
+                .map(|_| ())?,
             _ => bail!(Error::TagUnknown),
         }
         Ok(())
@@ -280,6 +283,9 @@ fn update_output(psbt_output: &mut psbt::Output, tags: Array) -> Result<()> {
             "tap_key_origins" => psbt_output.tap_key_origins = val.try_into()?,
             "proprietary" => psbt_output.proprietary = val.try_into()?,
             "unknown" => psbt_output.unknown = val.try_into()?,
+            "descriptor" => psbt_output
+                .update_with_descriptor_unchecked(&val.try_into()?)
+                .map(|_| ())?,
             _ => bail!(Error::TagUnknown),
         }
         Ok(())

--- a/src/stdlib/taproot.rs
+++ b/src/stdlib/taproot.rs
@@ -71,7 +71,7 @@ pub mod fns {
 
         if with_parity.unwrap_or(false) {
             let parity = tapinfo.output_key_parity().to_u8() as i64;
-            Ok(Value::array(vec![key.into(), parity.into()]))
+            Ok(Value::arr2(key, parity))
         } else {
             Ok(key.into())
         }
@@ -102,7 +102,7 @@ pub mod fns {
                 let script = script_ver.0.clone();
                 let version = vec![script_ver.1.to_consensus()];
                 let ctrl = tapinfo.control_block(script_ver).unwrap().serialize();
-                Value::array(vec![script.into(), version.into(), ctrl.into()])
+                Value::arr3(script, version, ctrl)
             })
             .collect();
 

--- a/src/stdlib/taproot.rs
+++ b/src/stdlib/taproot.rs
@@ -411,6 +411,24 @@ impl TryFrom<Value> for bitcoin::secp256k1::schnorr::Signature {
         Ok(Self::from_slice(&val.into_bytes()?)?)
     }
 }
+impl TryFrom<Value> for bitcoin::taproot::Signature {
+    type Error = Error;
+    fn try_from(val: Value) -> Result<Self> {
+        Ok(Self::from_slice(&val.into_bytes()?)?)
+    }
+}
+impl TryFrom<Value> for bitcoin::taproot::LeafVersion {
+    type Error = Error;
+    fn try_from(val: Value) -> Result<Self> {
+        Ok(Self::from_consensus(val.into_u8()?)?)
+    }
+}
+impl TryFrom<Value> for bitcoin::taproot::ControlBlock {
+    type Error = Error;
+    fn try_from(val: Value) -> Result<Self> {
+        Ok(Self::decode(&val.into_bytes()?)?)
+    }
+}
 
 impl PrettyDisplay for TaprootSpendInfo {
     const AUTOFMT_ENABLED: bool = true;

--- a/src/stdlib/taproot.rs
+++ b/src/stdlib/taproot.rs
@@ -71,7 +71,7 @@ pub mod fns {
 
         if with_parity.unwrap_or(false) {
             let parity = tapinfo.output_key_parity().to_u8() as i64;
-            Ok(Value::arr2(key, parity))
+            Ok(Value::array_of((key, parity)))
         } else {
             Ok(key.into())
         }
@@ -89,7 +89,7 @@ pub mod fns {
         }))
     }
 
-    /// tr::scripts(TapInfo) -> Array<(Script, Bytes version, Bytes control_block)>
+    /// tr::scripts(TapInfo) -> Array<(Script, Int version, Bytes control_block)>
     ///
     /// Get the scripts in this TapInfo with their control blocks
     pub fn scripts(args: Array, _: &ScopeRef) -> Result<Value> {
@@ -99,10 +99,8 @@ pub mod fns {
             .script_map()
             .keys()
             .map(|script_ver| {
-                let script = script_ver.0.clone();
-                let version = vec![script_ver.1.to_consensus()];
                 let ctrl = tapinfo.control_block(script_ver).unwrap().serialize();
-                Value::arr3(script, version, ctrl)
+                Value::array_of((script_ver.0.clone(), script_ver.1.to_consensus(), ctrl))
             })
             .collect();
 

--- a/web/js/stdlib-wordlist.json
+++ b/web/js/stdlib-wordlist.json
@@ -463,6 +463,50 @@
       "$n, $val"
     ],
     [
+      "psbt",
+      "[native]"
+    ],
+    [
+      "psbt::combine",
+      "[native]"
+    ],
+    [
+      "psbt::create",
+      "[native]"
+    ],
+    [
+      "psbt::extract",
+      "[native]"
+    ],
+    [
+      "psbt::fee",
+      "[native]"
+    ],
+    [
+      "psbt::finalize",
+      "[native]"
+    ],
+    [
+      "psbt::sighash",
+      "[native]"
+    ],
+    [
+      "psbt::sign",
+      "[native]"
+    ],
+    [
+      "psbt::try_finalize",
+      "[native]"
+    ],
+    [
+      "psbt::try_sign",
+      "[native]"
+    ],
+    [
+      "psbt::update",
+      "[native]"
+    ],
+    [
       "pubkey",
       "[native]"
     ],


### PR DESCRIPTION
- New `PSBT` runtime data type
- Support for Create, Update, Sign, Combine, Finalize and Extract as defined in BIP 174
  - `psbt::create([ "unsigned_tx": .., "inputs": ..., .... ])` (aliased as `psbt()`)
  - `psbt::update($psbt, [ ... ])`
  - `psbt::sign($psbt, $keys)`
  - `psbt::combine($psbt1, $psbt2)`
  - `psbt::finalize($psbt)`
  - `psbt::extract($psbt) -> Transaction`
- `psbt($bytes)` to decode from bytes, `bytes($psbt)` to encode
- `psbt::fee($psbt)` to get the fee
- `psbt::sighash($psbt, $input_index)` to compute sighash



Example usage:

```hack
$alice = tprv8ZgxMBicQKsPeFAUridHPMivQZ2Z8TwX9uSwjyRSHS4Bc57JFFd5F58G1NayGS9sUAThjnco6Pm4u8rX2UDZ8inoTHhejgeKbhP9FjGu5Pa;

// Funding txo to use as input
$funding_desc = wpkh($alice/0/10);
$funding_tx_outpoint = 17e682f060b5f8e47ea04c5c4855908b0a5ad612022260fe50e11ecb0cc0ab76:1;
$funding_utxo = $funding_desc:0.001 BTC;

// Create PSBT
$psbt = psbt [
  "tx": [
    "inputs": [ $funding_tx_outpoint ],
    "outputs": [
      tb1qtpuwsvnu744slu3wg0m75c4whk2g4cuyz0v9jw: 0.0007 BTC,
      wpkh($alice/1/5): 0.0002 BTC, // change
    ]
  ],
  "inputs": [
    0: [
      "utxo": $funding_utxo,
      "descriptor": $funding_desc,
    ],
  ]
];
assert::eq(psbt::fee($psbt), 0.0001 BTC);

// Sign PSBT
$signed_psbt = psbt::sign($psbt, $alice);

// Finalize PSBT
$finalized_psbt = psbt::finalize($signed_psbt);

// Extract transaction
$tx = psbt::extract($finalized_psbt);

// Or sign+finalize+extract with the pipe operator:
$tx = $psbt | psbt::sign($alice) | psbt::finalize() | psbt::extract();
```

Decoding PSBT from bytes:

```hack
$psbt = psbt(0x70736274ff010071020000000176abc00ccb1ee150fe60220212d65a0a8b9055485c4ca07ee4f8b560f082e6170100000000ffffffff0270110100000000001600145878e8327cf56b0ff22e43f7ea62aebd948ae384204e0000000000001600140e576fd6f7b60a2be97b51ca57c44f3e032727df000000000001011fa08601000000000016001451d62eb45eff99ee4d83230f388764ef91908937220603e1cfd319d56b1bd284589e332f27b3b32c111bd2328fba545e9e1dfd44c4a9130ccec15cac000000000a000000000000);
$signed_psbt = psbt::sign($psbt);

// Or just pass the bytes directly anywhere a PSBT is accepted
psbt::sign(0x70736274ff010071020000000176abc00ccb1ee150fe60220212d65a0a8b9055485c4ca07ee4f8b560f082e6170100000000ffffffff0270110100000000001600145878e8327cf56b0ff22e43f7ea62aebd948ae384204e0000000000001600140e576fd6f7b60a2be97b51ca57c44f3e032727df000000000001011fa08601000000000016001451d62eb45eff99ee4d83230f388764ef91908937220603e1cfd319d56b1bd284589e332f27b3b32c111bd2328fba545e9e1dfd44c4a9130ccec15cac000000000a000000000000
         , $alice)
```