### PR TITLE
Simplified psbt::tx() API to initialize a tx alongside its PSBT metadata

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -269,17 +269,17 @@ pub enum RuntimeError {
     #[error("PSBT output #{0} does not exists")]
     PsbtOutputNotFound(usize),
 
-    #[error("PSBT finalization errors: {}", .0.into_iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))]
+    #[error("PSBT finalization error(s): {}", .0.into_iter().map(ToString::to_string).collect::<Vec<_>>().join(" · "))]
     PsbtFinalize(Vec<miniscript::psbt::Error>),
 
-    #[error("PSBT signing errors: {}", .0.into_iter().map(|(i, e)| format!("input #{}: {}", i, e)).collect::<Vec<_>>().join(", "))]
+    #[error("PSBT signing error(s): {}", .0.into_iter().map(|(i, e)| format!("input #{}: {}", i, e)).collect::<Vec<_>>().join(" · "))]
     PsbtSigning(bitcoin::psbt::SigningErrors),
 
-    #[error("Missing \"input\" field to construct the PSBT transaction input")]
-    PsbtAddInMissingTxIn,
+    #[error("Missing fields to construct PSBT transaction input (prevout is required)")]
+    PsbtTxInMissingFields,
 
-    #[error("Missing \"output\" field to construct the PSBT transaction output")]
-    PsbtAddOutMissingTxOut,
+    #[error("Missing fields to construct PSBT transaction output (amount and scriptPubKey/descriptor are required)")]
+    PsbtTxOutMissingFields,
 
     // Generic error raised from user-land Minsc code
     #[error("Exception: {0}")]


### PR DESCRIPTION
This removes support for the previously available "add_inputs"/"add_outputs", which was but should not be usable when updating existing PSBT (for v0 at least).

The new `psbt::tx()` API is only available for the initial PSBT creation, and improves upon the prior "add_input"/"add_outputs" ergonomics.

Example use with multisig and timelocks ([run in playground](https://min.sc/v0.3/#c=%24alice%20%3D%20tprv8ZgxMBicQKsPdJ4fACcDyaRS9vuxRtBrj69BEficvR7UEk9DhyCVzQCYws8ZNqnY8U3C6vJ9xK8BPHjb9GGCXkdcyRqdF6Uy3gsGe4gjAgt%3B%0A%24bob%20%3D%20tprv8ZgxMBicQKsPdtLA8dMLSyajr6eKVyw2XpurTNH4vSsEouJbgEcg6yHctAGtdbu2N8JvpuUmT2mRHnhjuAQt7yDnCcBSqNAMqwUDGtyqhKR%3B%0A%0A%24psbt%20%3D%20psbt%3A%3Atx%20%5B%0A%20%20%22version%22%3A%202%2C%0A%20%20%22inputs%22%3A%20%5B%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%22prevout%22%3A%2001ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b%3A0%2C%0A%20%20%20%20%20%20%22utxo%22%3A%20wpkh%28%24alice%2F0%2F100%29%3A0.3%20BTC%2C%0A%20%20%20%20%5D%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%22prevout%22%3A%20d5110331f105a29677a2f1b016c6db28e5fc1062650064ba926590d9a43862d3%3A2%2C%0A%20%20%20%20%20%20%22utxo%22%3A%20tr%28%24bob%2F0%2F72%29%3A0.9%20BTC%2C%0A%20%20%20%20%5D%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%22prevout%22%3A%20b09229665ef21aa1d66d44e9022ca66dc96c0bd3018b45cf4cc1efd5ae878a86%3A1%2C%0A%20%20%20%20%20%20%22utxo%22%3A%20wsh%28pk%28%24bob%2F0%2F2%29%20%26%26%20pk%28%24alice%2F0%2F6%29%29%3A5%20BTC%2C%0A%20%20%20%20%5D%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%22prevout%22%3A%20386f2ba8c5b5b2f690337795d306d73e7f7e8167f7cdfadb1a5712f70b492a1f%3A5%2C%0A%20%20%20%20%20%20%22utxo%22%3A%20tr%28pk%28%24bob%2F0%2F2%29%20%26%26%20older%281%20month%29%29%3A0.2%20BTC%2C%0A%20%20%20%20%20%20%22sequence%22%3A%201%20month%2C%0A%20%20%20%20%5D%0A%20%20%5D%2C%0A%20%20%22outputs%22%3A%5B%0A%20%20%20%20wpkh%28%24alice%2F1%2F4%29%3A1.5%20BTC%2C%0A%20%20%20%20tr%28%24bob%2F1%2F8%29%3A1.7%20BTC%2C%0A%20%20%20%20wsh%28pk%28%24bob%2F8%29%20%26%26%20pk%28%24alice%2F8%29%29%3A0.1%20BTC%2C%0A%20%20%5D%0A%5D%3B%0A%0Aassert%3A%3Aeq%28psbt%3A%3Afee%28%24psbt%29%2C%203.1%20BTC%29%3B%0A%0A%24tx%20%3D%20psbt%3A%3Aextract%28psbt%3A%3Afinalize%28psbt%3A%3Asign%28%24psbt%2C%20%5B%20%24alice%2C%20%24bob%20%5D%29%29%29%3B)):

```hack
$alice = tprv8ZgxMBicQKsPdJ4fACcDyaRS9vuxRtBrj69BEficvR7UEk9DhyCVzQCYws8ZNqnY8U3C6vJ9xK8BPHjb9GGCXkdcyRqdF6Uy3gsGe4gjAgt;
$bob = tprv8ZgxMBicQKsPdtLA8dMLSyajr6eKVyw2XpurTNH4vSsEouJbgEcg6yHctAGtdbu2N8JvpuUmT2mRHnhjuAQt7yDnCcBSqNAMqwUDGtyqhKR;

$psbt = psbt::tx [
  "version": 2,
  "inputs": [
    [
      "prevout": 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b:0,
      "utxo": wpkh($alice/0/100):0.3 BTC,
    ],
    [
      "prevout": d5110331f105a29677a2f1b016c6db28e5fc1062650064ba926590d9a43862d3:2,
      "utxo": tr($bob/0/72):0.9 BTC,
    ],
    [
      "prevout": b09229665ef21aa1d66d44e9022ca66dc96c0bd3018b45cf4cc1efd5ae878a86:1,
      "utxo": wsh(pk($bob/0/2) && pk($alice/0/6)):5 BTC,
    ],
    [
      "prevout": 386f2ba8c5b5b2f690337795d306d73e7f7e8167f7cdfadb1a5712f70b492a1f:5,
      "utxo": tr(pk($bob/0/2) && older(1 month)):0.2 BTC,
      "sequence": 1 month,
    ]
  ],
  "outputs":[
    wpkh($alice/1/4):1.5 BTC,
    tr($bob/1/8):1.7 BTC,
    wsh(pk($bob/8) && pk($alice/8)):0.1 BTC,
  ]
];

assert::eq(psbt::fee($psbt), 3.1 BTC);

$tx = psbt::extract(psbt::finalize(psbt::sign($psbt, [ $alice, $bob ])));
```