### PR TITLE
Support BIP32 hardended derivation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -155,7 +155,7 @@ pub enum RuntimeError {
     #[error("Invalid arguments")]
     InvalidArguments,
 
-    #[error("Cannot derive policy/miniscript/descriptor without inner wildcard keys")]
+    #[error("Cannot derive policy/descriptor without inner wildcard keys")]
     NonDeriveableNoWildcard,
 
     #[error("Data type cannot be derived")]
@@ -208,6 +208,12 @@ pub enum RuntimeError {
 
     #[error("cannot mix number types ({0} and {1}). convert with explicit int()/float()")]
     InfixOpMixedNum(Box<Value>, Box<Value>),
+
+    #[error("BIP32 derivation error: {0}")]
+    SlashBip32Derive(#[source] Box<RuntimeError>),
+
+    #[error("Number division cannot be used with BIP32 modifiers (', h and *)")]
+    SlashUnexpectedBip32Mod,
 
     #[error("Invalid merkle root hash: {0}")]
     InvalidMerkleRoot(#[source] hashes::FromSliceError),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -55,7 +55,7 @@ Expr = {
   And,
   Or,
   IfExpr,
-  ChildDerive,
+  SlashOp,
   FnExpr,
   Infix,
   ColonOp,
@@ -103,8 +103,13 @@ Number = { Int, Float };
 Int: Expr = INT =>? Ok(i64::from_str(<>).map_err(ParseError::from)?.into());
 Float: Expr = FLOAT =>? Ok(f64::from_str(<>).map_err(ParseError::from)?.into());
 
-IdentTerm: ast::Ident = IDENT => ast::Ident(<>.into());
 Ident: Expr = IdentTerm => Expr::Ident(<>);
+IdentTerm: ast::Ident = {
+  IDENT => ast::Ident(<>.into()),
+  // 'h' is a keyword token used for bip32 hardened derivation, but it is only usable in places where
+  // identifiers aren't so it is safe not to treat it as a reserved keyword (which would be the default)
+  "h" => ast::Ident(<>.into()),
+};
 
 Call = { SimpleCall, ExprCall, PipeCall };
 
@@ -134,7 +139,7 @@ IfExprThenVal = { BlockExpr, "then" <Expr> };
 
 And: Expr = <List2<AndOrBranch, "&&">> => ast::And(<>).into();
 Or: Expr = <List2<AndOrBranch, "||">> => ast::Or(<>).into();
-AndOrBranch = { SimpleExpr, ChildDerive };
+AndOrBranch = { SimpleExpr, SlashOp };
 
 Thresh: Expr = <thresh:SExpr> "of" <policies:SimpleExpr> =>
   ast::Thresh { thresh: thresh.into(), policies: policies.into() }.into();
@@ -198,27 +203,12 @@ Bytes: Expr = {
 //
 // Bech32 addresses are only supported up to 63 characters. This is OK for Segwit v0/v1 (always 42/62),
 // but may not be sufficient for future versions which can be up to 74 characters long.
-// Supporting them requires resolving the ambiguity with 64-characters long hexadecimal strings.
+// Supporting them requires resolving the ambiguity with "0x"-less 64-characters long hexadecimal strings.
 Address: Expr = ADDRESS =>? Ok(Expr::Address(<>.parse().map_err(ParseError::from)?));
 
 String: Expr = STRING => Expr::string_from_escaped_str(&<>[1..<>.len()-1]);
 
-// BIP32 child key derivation
-ChildDerive: Expr = {
-    <parent:SimpleExpr> "/" <path:List1<ChildDerivePart, "/">> <wildcard:ChildDeriveWildcard?> =>
-      ast::ChildDerive { parent: parent.into(), path, is_wildcard: wildcard.is_some() }.into(),
-    <parent:SimpleExpr> <wildcard:ChildDeriveWildcard> =>
-      ast::ChildDerive { parent: parent.into(), path: vec![], is_wildcard: true }.into(),
-};
-ChildDerivePart: Expr = {
-  SimpleExpr,
-  // For compatibility with the BIP389 multipath descriptor syntax: XPUB/0/<0;1>/9
-  // This can alternatively be expressed using standard Minsc arrays: XPUB/0/[0,1]/9
-  "<" <List2<SimpleExpr, ";">> ">" => ast::Array(<>).into(),
-};
-// Allow `xpub/ *` so that it doesn't look like a comment.
-ChildDeriveWildcard = { "/*", "/ *" };
-
+// Script fragment enclosed in backticks
 ScriptFrag: Expr = "`" <fragments:ScriptFragPart*> "`" => ast::ScriptFrag { fragments }.into();
 ScriptFragPart = {
   Ident, Number, String, Bytes, PubKey, DateTime, SimpleCall, ArrayAccess,
@@ -269,7 +259,7 @@ FnExprParams = {
 // Binary infix operators with left associativity
 Infix: Expr = <lhs:InfixLHS> <op:InfixOp> <rhs:InfixRHS> =>
    ast::Infix { op, lhs: lhs.into(), rhs: rhs.into() }.into();
-InfixRHS = { SimpleExpr, And, Or, ChildDerive, Duration }; // Expr - IfExpr - FnExpr - Infix - InfixColon
+InfixRHS = { SimpleExpr, And, Or, SlashOp, Duration }; // Expr - IfExpr - FnExpr - Infix - ColonOp
 InfixLHS = { InfixRHS, Infix }; // left-associative recursion
 InfixOp = { InfixOpScriptSafe, InfixOpNonScript };
 InfixOpScriptSafe: ast::InfixOp = {
@@ -299,6 +289,29 @@ ColonRHS = { ColonLHS, ColonOp, FnExpr, IfExpr }; // right-associative recursion
 // so that it can be used unambiguously as an AndOrBranch element without requiring parenthesis.
 InfixProb: Expr = <lhs:SExpr> "@" <rhs:SimpleExpr> =>
   ast::Infix { op: ast::InfixOp::Prob, lhs: lhs.into(), rhs: rhs.into() }.into();
+
+// Slash operator (binary & left-associative). Used for both number division and BIP32 derivation.
+// Defined separately from Infix to support BIP32's modifiers (' h *) and BIP389's syntax in the RHS
+SlashOp: Expr = <lhs:SlashLHS> "/" <rhs:SlashRHS> => ast::SlashOp { lhs: lhs.into(), rhs }.into();
+SlashLHS = { SimpleExpr, SlashOp }; // left-associative recursion
+SlashRHS: ast::SlashRhs = {
+  // Number division or BIP32 non-hardened key derivation
+  SimpleExpr => ast::SlashRhs::Expr(<>.into()),
+
+  // BIP32 hardened key derivation
+  <SimpleExpr> HardenedModifier => ast::SlashRhs::HardenedDerivation(<>.into()),
+
+  // BIP32 wildcard modifiers
+  "*" => ast::SlashRhs::UnhardenedWildcard,
+  "*" HardenedModifier => ast::SlashRhs::HardenedWildcard,
+
+  // For compatibility with the BIP389 multipath descriptor syntax: XPUB/0/<0;1>/9
+  // Mixing up hardened and non-hardened is currently unsupported.
+  // Can alternatively be expressed using standard Minsc arrays: XPUB/0/[0,1]/9 or XPUB/0/[0,1]h/9
+  "<" <List2<SimpleExpr, ";">> ">" => ast::SlashRhs::Expr(Box::new(ast::Array(<>).into())),
+  "<" <List2<(<SimpleExpr> HardenedModifier), ";">> ">" => ast::SlashRhs::HardenedDerivation(Box::new(ast::Array(<>).into())),
+};
+HardenedModifier = { "'", "h" };
 
 Not: Expr = "!" <SimpleExpr> =>
   ast::Not(<>.into()).into();

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -66,12 +66,13 @@ pub fn run_playground(code: &str, network: &str) -> std::result::Result<JsValue,
         if let (Some(desc), None, None) = (&desc, &script, &addr) {
             // Multi-path descriptors cannot be used to derive scripts/addresses
             if !desc.is_multipath() {
-                addr = Some(desc.to_address(network)?);
-                script = Some(match desc {
+                // may fail if the descriptor pubkey has unresolved hardened derivation steps
+                addr = desc.to_address(network).ok();
+                script = match desc {
                     // Use the scriptPubKey for Taproot descriptor (it has no explicitScript)
-                    Descriptor::Tr(_) => desc.to_script_pubkey()?,
-                    _ => desc.to_explicit_script()?,
-                })
+                    Descriptor::Tr(_) => desc.to_script_pubkey().ok(),
+                    _ => desc.to_explicit_script().ok(),
+                }
             }
         }
 

--- a/web/js/codemirror-minsc.js
+++ b/web/js/codemirror-minsc.js
@@ -57,6 +57,11 @@ CodeMirror.defineSimpleMode("minsc",{
     // PUSH in Script's Debug format
     {regex: /(OP_PUSHBYTES\w*)\s*([a-f0-9]+)\b/, token: ["variable-2", "number"]},
 
+    // BIP32 derivation
+    {regex: /(\d+)(h)\b/, token: ["number", "operator"]}, // hardened derivation step with number literal
+    {regex: /\*h\b/, token: "operator"}, // hardened wildcard
+    {regex: /m\//, token: "operator"},
+
     // Variables
     {regex: /[A-Z$][A-Z0-9_]+\b/, token: "variable-2"}, // different look for all-caps identifiers, typically OP_CODES
     {regex: /[$a-zA-Z_][$a-zA-Z_0-9]*(?:::[a-zA-Z0-9_$]+)*\b/, token: "variable-3"},
@@ -72,6 +77,7 @@ CodeMirror.defineSimpleMode("minsc",{
     {regex: /\s*@[\w_$:]*/, token: "property"},
     {regex: /(#)\s*("(?:[^\\]|\\.)*?")/, token: ["property", "comment"]},
     {regex: /#/, token: "property"},
+
 
     // Infix operators
     {regex: /[-+\/*<>!;@]|[=!<>]=|&&|\|\||\|/, token: "operator"},


### PR DESCRIPTION
Refactored into a new `SlashOp`.

Supports both `XPRIV/0'` and `XPRIV/0h`.
Or with the wildcard modifier: `XPRIV/*'` and `XPRIV/*h`.

When converted into a pubkey, all hardened derivation steps are resolved and moved to the key origin, leaving only tailing non-hardened derivation steps. For example, `pubkey(XPRIV/1'/2'/3/4)` would give back `[ffd2a052/1'/2']XPUB/3/4` (`ffd2a052` being `XPRIV`'s fingerprint).