### PR TITLE
Extract PSBT input descriptor from utxo field

### DIFF
--- a/src/stdlib/miniscript.rs
+++ b/src/stdlib/miniscript.rs
@@ -292,4 +292,8 @@ impl Value {
     pub fn is_policy_coercible(&self) -> bool {
         matches!(self, Value::Policy(_) | Value::PubKey(_) | Value::SecKey(_))
     }
+
+    pub fn is_descriptor(&self) -> bool {
+        matches!(self, Value::Descriptor(_))
+    }
 }


### PR DESCRIPTION
Adds an alternative way to specify the PSBT input `descriptor`/`utxo` (aka `witness_utxo`).

```hack
psbt [
  "tx": ...,
  "inputs": [
    // Instead of auto-deriving the `utxo` from the `descriptor` and `amount` fields, like so:
    0: [ "descriptor": wpkh($alice/100), "amount": 1 BTC ],

    // It is now also possible to specify the `utxo` and extract the `descriptor` from it, like so:
    1: [ "utxo": wpkh($alice/100):1 BTC ],
  ]
]
```