### PR TITLE
Reconstruct & retain the TaprootSpendInfo tree structure

### DIFF
--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -422,7 +422,7 @@ impl fmt::Display for Value {
             Value::Array(x) => write!(f, "{}", x.pretty(None)),
             Value::Transaction(x) => write!(f, "{}", x.pretty(None)),
             Value::Script(x) => write!(f, "{}", x.pretty(None)),
-            Value::TapInfo(x) => write!(f, "{}", x.pretty(None)), // not round-trip-able for >2 scripts
+            Value::TapInfo(x) => write!(f, "{}", x.pretty(None)),
         }
     }
 }


### PR DESCRIPTION
Reconstruct the Taproot tree structure from the TaprootSpendInfo, using the merkle proofs associated with its scripts.

This is necessary to make a round-trip-able representation, fixing the previous buggy behavior as was documented in `PrettyDisplay for TaprootSpendInfo`: 

```
// The Taproot script tree is displayed as a flat array, which loses the the Taproot tree structure information when there
// are more than two scripts. "(not tree)" is added to inform users, and to make the serialized string invalid as a
// Minsc expression to prevent it from being used to reconstruct a TaprootSpendInfo with the wrong tree structure.
// FIXME deduce the original TapTree structure from the TaprootSpendInfo merkle paths (not available in rust-bitcoin)
write!(f, "(not tree)")?;
```