### PR TITLE
Implement ReprExpr, a round-trip-able string representation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::convert::TryInto;
 
 pub use error::{Error, ParseError, RuntimeError};
 pub use parser::{ast, Expr, Ident, Library, Stmt};
-pub use runtime::{Evaluate, Execute, Number, Scope, ScopeRef, Value};
+pub use runtime::{Evaluate, Execute, ExprRepr, Number, Scope, ScopeRef, Value};
 pub use util::PrettyDisplay;
 
 use miniscript::{descriptor, policy};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -15,7 +15,7 @@ pub mod value;
 pub use array::Array;
 pub use function::{Call, Function};
 pub use scope::{Mutable, ReadOnly, Scope, ScopeRef};
-pub use value::{FromValue, Number, Number::*, Symbol, Value};
+pub use value::{ExprRepr, FromValue, Number, Number::*, Symbol, Value};
 
 /// Evaluate an expression. Expressions have no side-effects and return a value.
 pub trait Evaluate {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -52,6 +52,7 @@ pub fn attach_stdlib(scope: &ScopeRef<Mutable>) {
 
         // Development utilities
         scope.set_fn("debug", fns::debug).unwrap();
+        scope.set_fn("repr", fns::repr).unwrap();
         scope.set_fn("env", fns::env).unwrap();
 
         // Constants
@@ -77,7 +78,7 @@ pub fn attach_stdlib(scope: &ScopeRef<Mutable>) {
 pub mod fns {
     use super::*;
     use crate::runtime::{Call, Function};
-    use crate::util::PrettyDisplay;
+    use crate::{ExprRepr, PrettyDisplay};
 
     /// Get the argument type as a string
     /// One of: pubkey, number, bool, bytes, policy, withprob, descriptor, address, script, function, network, tapinfo, array, symbol
@@ -219,6 +220,14 @@ pub mod fns {
         // This works because the Value's Display returns Symbol strings as-is, with no quoting or escaping.
         // This is a serious misuse of what Symbols are meant for, but I guess it works >.<
         Ok(Symbol::new(Some(debug_str)).into())
+    }
+
+    /// repr(Any) -> String
+    ///
+    /// Get the ExprRepr representation of the value, which can be round-tripped
+    /// as a Minsc expression to reproduce the value.
+    pub fn repr(args: Array, _: &ScopeRef) -> Result<Value> {
+        Ok(args.arg_into::<Value>()?.repr_str().into())
     }
 
     /// Get env vars from the local and parent scopes

--- a/src/util.rs
+++ b/src/util.rs
@@ -470,7 +470,7 @@ impl<W: fmt::Write + ?Sized> fmt::Write for LimitedWriter<'_, W> {
 }
 
 /// Display-like with custom formatting options, newlines/indentation handling and the ability to implement on foreign types
-pub trait PrettyDisplay: Sized + fmt::Debug {
+pub trait PrettyDisplay: Sized {
     const AUTOFMT_ENABLED: bool;
     const MAX_ONELINER_LENGTH: usize = 125;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-use crate::eval;
+use crate::{eval, ExprRepr};
 
 #[cfg(feature = "wee_alloc")]
 #[global_allocator]
@@ -8,8 +8,8 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
 pub fn run(code: &str) -> Result<JsValue, JsValue> {
-    let value = eval(code).map_err(|e| e.to_string())?;
-    Ok(JsValue::from_str(&value.to_string()))
+    let result = eval(code).map_err(|e| e.to_string())?;
+    Ok(JsValue::from_str(&result.repr_str()))
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Encodes Minsc `Value`s as a string Minsc expression that, when evaluated, reproduces the original `Value`.

Used as the serialization format for passing around Values back-and-forth between the Minsc runtime and other runtimes (currently used for WASM/JS).

For many types the `Display`/`PrettyDisplay` already is round-trip-able, but some types require special handling and/or can be encoded more compactly/accurately for a ReprExpr representation.