### PR TITLE
Support providing just the preimage for PSBT inputs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,9 +34,6 @@ pub enum RuntimeError {
     #[error("Missing expected return value, set a final expression or a main() function")]
     NoReturnValue,
 
-    #[error("Undefined function: {0}")]
-    FnNotFound(Ident),
-
     #[error("Undefined variable: {0}")]
     VarNotFound(Ident),
 
@@ -240,6 +237,9 @@ pub enum RuntimeError {
 
     #[error("Invalid taproot script, expecting Policy/Script or an array of them")]
     TaprootInvalidScript,
+
+    #[error["Miniscript hash pre-images must be exactly 32 bytes long"]]
+    InvalidPreimageLen,
 
     #[error("Expected a tuple array of 2 elements, not {0:?}")]
     InvalidTuple(Box<Value>),


### PR DESCRIPTION
Automatically converted into the hash->preimage lookup map.

For example, `"sha256_preimages": [ $mysecret ]` rather than having to
`"sha256_preimages": [ hash::sha256($mysecret): $mysecret ]`