### PR TITLE
PrettyDisplay for PSBTs

### DIFF
--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -417,7 +417,7 @@ impl fmt::Display for Value {
             Value::Function(x) => write!(f, "{}", x), // not round-trip-able (cannot be)
             Value::Network(x) => write!(f, "{}", x),
             Value::Symbol(x) => write!(f, "{}", x),
-            Value::Psbt(x) => write!(f, "{}", x.pretty(None)), // uses Debug, not round-trip-able (ExprRepr is)
+            Value::Psbt(x) => write!(f, "{}", x.pretty(None)),
             Value::SecKey(x) => write!(f, "{}", x.pretty(None)),
             Value::PubKey(x) => write!(f, "{}", x.pretty(None)),
             Value::Array(x) => write!(f, "{}", x.pretty(None)),
@@ -479,10 +479,8 @@ impl ExprRepr for Value {
             // These also have round-trip-able Display, but can be expressed more compactly/precisely for ExprRepr
             Transaction(tx) => write!(f, "tx(0x{})", bitcoin::consensus::serialize(tx).as_hex()),
             Script(script) => write!(f, "script(0x{})", script.as_bytes().as_hex()),
-            TapInfo(tapinfo) => tapinfo.repr_fmt(f),
-
-            // Psbt's Display uses the Debug representation which is not round-trip-able (but better to serialize as bytes anyway)
             Psbt(psbt) => write!(f, "psbt(0x{})", psbt.serialize().as_hex()),
+            TapInfo(tapinfo) => tapinfo.repr_fmt(f),
 
             // Descriptors require special handling when they have script paths (i.e. not (W)Pkh or script-less Tr)
             Descriptor(desc) => desc.repr_fmt(f),

--- a/src/stdlib/taproot.rs
+++ b/src/stdlib/taproot.rs
@@ -594,3 +594,5 @@ impl PrettyDisplay for bitcoin::taproot::TapTree {
         write!(f, "{}", tree.pretty(indent))
     }
 }
+
+impl_simple_pretty!(TapLeafHash, h, "{}", h);

--- a/src/stdlib/taproot.rs
+++ b/src/stdlib/taproot.rs
@@ -576,3 +576,21 @@ impl<'a> PrettyDisplay for NodeTree<'a> {
         }
     }
 }
+
+impl PrettyDisplay for bitcoin::taproot::TapTree {
+    const AUTOFMT_ENABLED: bool = false; // Enabled for the rendered NodeTree
+
+    fn pretty_fmt<W: fmt::Write>(&self, f: &mut W, indent: Option<usize>) -> fmt::Result {
+        // Construct a TaprootSpendInfo with a dummy key so that it may be used for reconstruct_tree()
+        // TODO reconstructing the tree without going through TaprootSpendInfo is possible and more efficient.
+        lazy_static! {
+            static ref DUMMY_KEY: XOnlyPublicKey =
+                "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+                    .parse()
+                    .unwrap();
+        }
+        let tapinfo = TaprootSpendInfo::from_node_info(&EC, *DUMMY_KEY, self.node_info().clone());
+        let tree = reconstruct_tree(&tapinfo).expect("invalid TapTree");
+        write!(f, "{}", tree.pretty(indent))
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, IntoDerivationPath};
 use bitcoin::hashes::{sha256, Hash};
+use bitcoin::hex::DisplayHex;
 use bitcoin::{secp256k1, PublicKey};
 use miniscript::descriptor::{
     DerivPaths, DescriptorMultiXKey, DescriptorPublicKey, DescriptorSecretKey, Wildcard,
@@ -553,6 +554,17 @@ where
     }
     write!(w, "{newline_or_space}{:indent_w$}]", "")
 }
+
+impl<T: PrettyDisplay> PrettyDisplay for Vec<T> {
+    const AUTOFMT_ENABLED: bool = true;
+    fn pretty_fmt<W: fmt::Write>(&self, f: &mut W, indent: Option<usize>) -> fmt::Result {
+        fmt_list(f, self.iter(), indent, |f, el, inner_indent| {
+            write!(f, "{}", el.pretty(inner_indent))
+        })
+    }
+}
+
+impl_simple_pretty!(Vec<u8>, bytes, "0x{}", bytes.as_hex());
 
 pub fn indentation_params(indent: Option<usize>) -> (&'static str, Option<usize>, usize, usize) {
     let newline_or_space = iif!(indent.is_some(), "\n", " ");


### PR DESCRIPTION
Implement a PrettyDisplay that renders PSBTs as (prettified) Minsc code with all the PSBT fields, which can be evaluated to reproduce the PSBT.

For example:
```
 psbt [
  "unsigned_tx": tx [
    "version": 2,
    "inputs": [ 72877bd944be3433d5030ef102922e52f7c40de8b5ca26fa8b7c724d341e936e:1 ],
    "outputs": [ tb1ql8nqx3q3v7napchr6ewy4tpyq5y08ywafwvvw6:0.499 BTC ]
  ],
  "version": 0,
  "inputs": [
    [
      "witness_utxo": tb1pm8kxapzrhq06zc8wz35txvysfwwleyldrjhd9txdqffqhs0cx56qwq7huf:0.5 BTC,
      "tap_scripts": [
        0xc050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0: `<0x12ad5a8f5be091db0a8283b193235b9f362abc5339f98298cea584d37bcc28f1> OP_CHECKSIG OP_SWAP <0xcdd808930c08aac51d20cdd5fb36ed3b866dd1f6633088324665bbe94e1039fd> OP_CHECKSIG OP_ADD OP_SWAP <0x9aca07d9b9c4df53eaab7f99d840c9460c3398595efea4f49b040bca5890db61> OP_CHECKSIG OP_ADD OP_SWAP OP_IF <0> OP_ELSE <0x627840> OP_CHECKSEQUENCEVERIFY OP_ENDIF OP_0NOTEQUAL OP_ADD <3> OP_EQUAL`
      ],
      "tap_key_origins": [
        [5c4b44b9/0]12ad5a8f5be091db0a8283b193235b9f362abc5339f98298cea584d37bcc28f1: [ f3ed9d69972f25b6765154300d464230bb325f79be193906c8c184643f74786a ],
        [f4ac30dd/]50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,
        [223a1e81/0]9aca07d9b9c4df53eaab7f99d840c9460c3398595efea4f49b040bca5890db61: [ f3ed9d69972f25b6765154300d464230bb325f79be193906c8c184643f74786a ],
        [4f46a32a/0]cdd808930c08aac51d20cdd5fb36ed3b866dd1f6633088324665bbe94e1039fd: [ f3ed9d69972f25b6765154300d464230bb325f79be193906c8c184643f74786a ]
      ],
      "tap_internal_key": 50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,
      "tap_merkle_root": f3ed9d69972f25b6765154300d464230bb325f79be193906c8c184643f74786a
    ]
  ],
  "outputs": [
    [ ]
  ]
]
```