### PR TITLE
X-only pubkeys conversion and encoding

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -149,6 +149,9 @@ pub enum RuntimeError {
     #[error("No inner wildcard xpubs to derive")]
     NonDeriveableNoWildcard,
 
+    #[error("Expected a definite pubkey with no underived wildcards, not {0}")]
+    UnexpectedWildcard(Box<miniscript::DescriptorPublicKey>),
+
     #[error("Data type cannot be derived")]
     NonDeriveableType,
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -406,6 +406,22 @@ where
     // XXX could use miniscript::translate_hash_clone!() if is used std::result:Result or if we avoided replacing Result with a type alias
 }
 
+// Keys utilities
+
+pub trait DescriptorPubKeyExt: Sized {
+    /// Convert into a DefiniteDescriptorKey. Errors if the descriptor contains underived wildcards.
+    fn ensure_definite(self) -> Result<miniscript::DefiniteDescriptorKey>;
+}
+impl DescriptorPubKeyExt for DescriptorPublicKey {
+    fn ensure_definite(self) -> Result<miniscript::DefiniteDescriptorKey> {
+        ensure!(
+            !self.has_wildcard(),
+            Error::UnexpectedWildcard(self.clone().into())
+        );
+        Ok(self.at_derivation_index(0).expect("valid index"))
+    }
+}
+
 pub trait DescriptorSecretKeyExt {
     /// Like `DescriptorPublicKey::full_derivation_paths()`, which isn't available for secret keys
     fn full_derivation_paths(&self) -> Vec<DerivationPath>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -411,6 +411,10 @@ where
 pub trait DescriptorPubKeyExt: Sized {
     /// Convert into a DefiniteDescriptorKey. Errors if the descriptor contains underived wildcards.
     fn ensure_definite(self) -> Result<miniscript::DefiniteDescriptorKey>;
+
+    fn derive_definite(self) -> Result<bitcoin::PublicKey> {
+        Ok(self.ensure_definite()?.derive_public_key(&EC)?)
+    }
 }
 impl DescriptorPubKeyExt for DescriptorPublicKey {
     fn ensure_definite(self) -> Result<miniscript::DefiniteDescriptorKey> {


### PR DESCRIPTION
- Implement `xonly()` to convert full keys into x-only. Always returned as a single key (the final derived key), as there's no way to represent x-only keys as an `Xpub`/`DescriptorPublicKey`.

- Correctly encode x-only pubkeys in Script fragments.

  If the pubkey was derived from an xpub, explicit `xonly()` is necessary. For example:

   ```hack
   $alice = tpubD6NzVbkrYhZ4WTSqGCZk1bdFkoP8iVat9EaDcKpKCf2DQ3RQ2TQ4s2SJrj4NzfuAyz3NNvFPUYm2MhBLw8dFzZSrf6TYo1xqfrjeP9XqgUn;

   $script = `xonly($alice/90) OP_CHECKSIG`;
   ```

   If the key was constructed as a single x-only pubkey it will remain an x-only even without an explicit `xonly()`, so this works as expected:

   ```hack
   $alice = pubkey(0xaf1d0519f60ae662d94ca98843376229ef68102f826800387d025d4d0e2c922b);

   $script = `$alice OP_CHECKSIG`;
   ```

    However the recommended practice is to always use `xonly()`, to help avoid potential mistakes.