### PR TITLE
Require pubkeys/descriptors to be definite where its expected

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ impl_from_variant!(ParseError, Error, Parse);
 
 #[derive(thiserror::Error, Debug)]
 pub enum RuntimeError {
-    #[error("Assigned variable name already exists: {0}")]
+    #[error("Variables are immutable, cannot assign over {0}")]
     AssignedVariableExists(Ident),
 
     #[error("Undefined variable: {0}")]
@@ -149,8 +149,17 @@ pub enum RuntimeError {
     #[error("No inner wildcard xpubs to derive")]
     NonDeriveableNoWildcard,
 
-    #[error("Expected a definite pubkey with no underived wildcards, not {0}")]
-    UnexpectedWildcard(Box<miniscript::DescriptorPublicKey>),
+    #[error("Expected a definite pubkey with no underived wildcards, not {0:#}")]
+    UnexpectedWildcardPubKey(Box<miniscript::DescriptorPublicKey>),
+
+    #[error("Expected a definite descriptor with no underived wildcards, not {0:#}")]
+    UnexpectedWildcardDescriptor(Box<crate::DescriptorDpk>),
+
+    #[error("Expected a definite pubkey with no multi-path derivations, not {0:#}")]
+    UnexpectedMultiPathPubKey(Box<miniscript::DescriptorPublicKey>),
+
+    #[error("Expected a definite descriptor with no multi-path derivations, not {0:#}")]
+    UnexpectedMultiPathDescriptor(Box<crate::DescriptorDpk>),
 
     #[error("Data type cannot be derived")]
     NonDeriveableType,

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -64,8 +64,8 @@ pub fn run_playground(code: &str, network: &str) -> std::result::Result<JsValue,
 
         // Display the explicitScript/scriptPubKey and address of descriptors
         if let (Some(desc), None, None) = (&desc, &script, &addr) {
-            // Multi-path descriptors cannot be used to derive scripts/addresses
-            if !desc.is_multipath() {
+            // Multi-path and wildcards descriptors cannot be used to derive scripts/addresses
+            if !desc.is_multipath() && !desc.has_wildcard() {
                 // may fail if the descriptor pubkey has unresolved hardened derivation steps
                 addr = desc.to_address(network).ok();
                 script = match desc {

--- a/src/stdlib/keys.rs
+++ b/src/stdlib/keys.rs
@@ -125,7 +125,7 @@ pub mod fns {
 
             // Convert into an x-only single pubkey with BIP32 origin information
             non_xonly => {
-                let pk = non_xonly.ensure_definite()?;
+                let pk = non_xonly.definite()?;
                 let derived_single_pk = pk.derive_public_key(&EC)?;
                 let derived_path = pk.full_derivation_path().ok_or(Error::InvalidMultiXpub)?;
 
@@ -202,7 +202,7 @@ impl TryFrom<Value> for secp256k1::SecretKey {
         Ok(match value.try_into()? {
             DescriptorSecretKey::Single(single_priv) => single_priv.key.inner,
             DescriptorSecretKey::XPrv(xprv) => {
-                // TODO derive wildcards (similarly to pubkeys via at_derivation_index)
+                // TODO ensure no wildcards, similarly to DescriptorPubKeyExt::definite()
                 xprv.xkey
                     .derive_priv(&EC, &xprv.derivation_path)?
                     .private_key
@@ -229,9 +229,7 @@ impl TryFrom<Value> for secp256k1::Keypair {
 impl TryFrom<Value> for bitcoin::PublicKey {
     type Error = Error;
     fn try_from(val: Value) -> Result<Self> {
-        Ok(DescriptorPublicKey::try_from(val)?
-            .at_derivation_index(0)?
-            .derive_public_key(&EC)?)
+        DescriptorPublicKey::try_from(val)?.derive_definite()
     }
 }
 

--- a/src/stdlib/miniscript.rs
+++ b/src/stdlib/miniscript.rs
@@ -302,7 +302,7 @@ impl TryFrom<Value> for Policy {
 impl TryFrom<Value> for miniscript::Descriptor<miniscript::DefiniteDescriptorKey> {
     type Error = Error;
     fn try_from(value: Value) -> Result<Self> {
-        Ok(Descriptor::try_from(value)?.definite())
+        Descriptor::try_from(value)?.definite()
     }
 }
 impl<Ctx: ScriptContext> TryFrom<Value> for Miniscript<Ctx> {


### PR DESCRIPTION
Previously, pubkeys/descriptors with underived wildcards would be derived with a final derivation step of `0` to make them definite.

With this change, an error is raised instead.

For example, `address(wpkh($alice/9/*))` was previously valid and equivalent to `address(wpkh($alice/9/0))`, and is now considered invalid.