### PR TITLE
Multi-path fixups & improvements

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -172,6 +172,9 @@ pub enum RuntimeError {
     )]
     InvalidDerivationCode,
 
+    #[error("Can't make a multi-Xpub from a multi-Xpriv with hardened derivation steps that are not shared among all paths")]
+    InvalidHardenedMultiXprvToXpub,
+
     #[error("Unexpected multi-path Xpriv, only single-path Xprivs or single keys are accepted")]
     InvalidMultiXprv,
 
@@ -222,7 +225,7 @@ pub enum RuntimeError {
     InvalidMerkleRoot(#[source] hashes::FromSliceError),
 
     #[error(
-        "Invalid public key length {0} (expected 33 for single key, 32 for x-only or 78 for xpub"
+        "Invalid public key length {0} (expected 33 for single key, 32 for x-only or 78 for xpub)"
     )]
     InvalidPubKeyLen(usize),
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -214,6 +214,16 @@ impl Evaluate for ast::ArrayAccess {
                 ensure!(index < single_descs.len(), Error::ArrayIndexOutOfRange);
                 single_descs.remove(index).into()
             }
+            Value::PubKey(pk) if pk.is_multipath() => {
+                let mut single_pks = pk.into_single_keys();
+                ensure!(index < single_pks.len(), Error::ArrayIndexOutOfRange);
+                single_pks.remove(index).into()
+            }
+            Value::SecKey(sk) if sk.is_multipath() => {
+                let mut single_sks = sk.into_single_keys();
+                ensure!(index < single_sks.len(), Error::ArrayIndexOutOfRange);
+                single_sks.remove(index).into()
+            }
             other => bail!(Error::NoArrayAccess(other.into())),
         })
     }

--- a/src/stdlib/keys.rs
+++ b/src/stdlib/keys.rs
@@ -13,7 +13,9 @@ use miniscript::descriptor::{
 
 use crate::ast::SlashRhs;
 use crate::runtime::{Array, Error, Evaluate, Mutable, Result, ScopeRef, Value};
-use crate::util::{hash_to_child_vec, DeriveExt, DescriptorPubKeyExt, PrettyDisplay, EC};
+use crate::util::{
+    hash_to_child_vec, DeriveExt, DescriptorPubKeyExt, DescriptorSecretKeyExt, PrettyDisplay, EC,
+};
 
 pub fn attach_stdlib(scope: &ScopeRef<Mutable>) {
     let mut scope = scope.borrow_mut();
@@ -261,7 +263,7 @@ impl TryFrom<Value> for DescriptorPublicKey {
     fn try_from(value: Value) -> Result<Self> {
         match value {
             Value::PubKey(pubkey) => Ok(pubkey),
-            Value::SecKey(seckey) => Ok(seckey.to_public(&EC)?),
+            Value::SecKey(seckey) => Ok(seckey.to_public_()?),
             // Bytes are coerced into a single PubKey if they are 33 or 32 bytes long,
             // or to an Xpub if they're 78 bytes long
             Value::Bytes(bytes) => Ok(match bytes.len() {

--- a/src/stdlib/miniscript.rs
+++ b/src/stdlib/miniscript.rs
@@ -46,9 +46,6 @@ pub fn attach_stdlib(scope: &ScopeRef<Mutable>) {
     // Other descriptor functions
     scope.set_fn("descriptor", fns::descriptor).unwrap();
     scope.set_fn("explicitScript", fns::explicitScript).unwrap();
-    scope
-        .set_fn("descriptor::singles", fns::descriptor_singles)
-        .unwrap();
 
     // Policy to Script compilation
     scope.set_fn("tapscript", fns::tapscript).unwrap();
@@ -244,15 +241,6 @@ pub mod fns {
     pub fn explicitScript(args: Array, _: &ScopeRef) -> Result<Value> {
         let descriptor: Descriptor = args.arg_into()?;
         Ok(descriptor.to_explicit_script()?.into())
-    }
-
-    /// descriptor::singles(Descriptor<Multi>) -> Array<Descriptor<Single>>
-    pub fn descriptor_singles(args: Array, _: &ScopeRef) -> Result<Value> {
-        let desc: Descriptor = args.arg_into()?;
-        let descs = desc.into_single_descriptors()?;
-        Ok(Value::array(
-            descs.into_iter().map(Value::Descriptor).collect(),
-        ))
     }
 }
 

--- a/src/stdlib/miniscript.rs
+++ b/src/stdlib/miniscript.rs
@@ -6,7 +6,7 @@ use miniscript::{ScriptContext, Threshold};
 
 use crate::runtime::scope::{Mutable, ScopeRef};
 use crate::runtime::{Array, Error, Evaluate, Execute, ExprRepr, Result, Value};
-use crate::util::{DescriptorExt, MiniscriptExt, EC};
+use crate::util::{DescriptorExt, MiniscriptExt, DescriptorSecretKeyExt};
 use crate::{ast, DescriptorDpk as Descriptor, MiniscriptDpk as Miniscript, PolicyDpk as Policy};
 
 pub use crate::runtime::AndOr;
@@ -279,7 +279,7 @@ impl TryFrom<Value> for Policy {
             Value::PubKey(pubkey) => Ok(Policy::Key(pubkey)),
             // SecKeys are coerced into a PubKey, then to a pk()
             Value::SecKey(seckey) => {
-                let pubkey = seckey.to_public(&EC)?;
+                let pubkey = seckey.to_public_()?;
                 Ok(Policy::Key(pubkey))
             }
             v => Err(Error::NotPolicyLike(v.into())),

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use crate::runtime::scope::{Mutable, ScopeRef};
 use crate::runtime::{Array, Error, Execute, Number, Result, Symbol, Value};
+use crate::util::DescriptorSecretKeyExt;
 use crate::Library;
 
 pub mod btc;
@@ -99,6 +100,8 @@ pub mod fns {
             Value::String(string) => string.len(),
             Value::Script(script) => script.into_bytes().len(),
             Value::Descriptor(desc) if desc.is_multipath() => desc.into_single_descriptors()?.len(),
+            Value::PubKey(pk) if pk.is_multipath() => pk.full_derivation_paths().len(),
+            Value::SecKey(sk) if sk.is_multipath() => sk.full_derivation_paths().len(),
             _ => bail!(Error::InvalidArguments),
         }
         .into())


### PR DESCRIPTION
Example code using the new/fixed features:

[(open in playground)](https://min.sc/v0.3/#c=%2F%2F%20Spend%20from%20a%20simple%20Taproot%20internal-key-only%20wallet%20using%20PSBT%0A%2F%2F%20Similarly%20to%20https%3A%2F%2Fgithub.com%2Frust-bitcoin%2Frust-bitcoin%2Fblob%2Fmaster%2Fbitcoin%2Fexamples%2Ftaproot-psbt-simple.rs%0A%0A%2F%2F%20Wallet%20setup%20%26%20Address%20generation%0A%0A%24sk%20%3D%20xprv9tuogRdb5YTgcL3P8Waj7REqDuQx4sXcodQaWTtEVFEp6yRKh1CjrWfXChnhgHeLDuXxo2auDZegMiVMGGxwxcrb2PmiGyCngLxvLeGsZRq%3B%0A%0A%24descs%20%3D%20tr%28%24sk%2F86%27%2F0%27%2F0%27%2F%3C0%3B1%3E%2F*%29%3B%0A%24external%20%3D%20%24descs.0%2C%20%24internal%20%3D%20%24descs.1%3B%0A%0A%24recv_addr%20%3D%20address%28%24external%2F0%29%3B%0A%0A%2F%2F%20Spend%20from%20wallet%0A%0A%24psbt%20%3D%20psbt%20%5B%0A%20%20%22inputs%22%3A%20%5B%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%22prevout%22%3A%20b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c%3A0%2C%0A%20%20%20%20%20%20%22utxo%22%3A%20%28%24external%2F0%29%3A0.2%20BTC%2C%0A%20%20%20%20%5D%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%22prevout%22%3A%2045bdbfc61243606521bb174473121b922cbebb983b628c191253d1e0e88b2d49%3A1%2C%0A%20%20%20%20%20%20%22utxo%22%3A%20%28%24internal%2F0%29%3A0.1%20BTC%2C%0A%20%20%20%20%5D%2C%0A%20%20%5D%2C%0A%20%20%22outputs%22%3A%20%5B%0A%20%20%20%20bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va%3A0.0499%20BTC%2C%0A%20%20%20%20%28%24internal%2F1%29%3A0.25%20BTC%2C%0A%20%20%5D%0A%5D%3B%0A%0A%24signed%20%3D%20psbt%3A%3Asign%28%24psbt%2C%20%24sk%29%3B%0A%24tx%20%3D%20psbt%3A%3Aextract%28psbt%3A%3Afinalize%28%24signed%29%29%3B%0A%24tx_hex%20%3D%20hex%28%24tx%29%3B)

```php
// Spend from a simple Taproot internal-key-only wallet using PSBT
// Similarly to https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/taproot-psbt-simple.rs

// Wallet setup & Address generation

$sk = xprv9tuogRdb5YTgcL3P8Waj7REqDuQx4sXcodQaWTtEVFEp6yRKh1CjrWfXChnhgHeLDuXxo2auDZegMiVMGGxwxcrb2PmiGyCngLxvLeGsZRq;

$descs = tr($sk/86'/0'/0'/<0;1>/*);
$external = $descs.0, $internal = $descs.1;

$recv_addr = address($external/0);

// Spend from wallet

$psbt = psbt [
  "inputs": [
    [
      "prevout": b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c:0,
      "utxo": ($external/0):0.2 BTC,
    ],
    [
      "prevout": 45bdbfc61243606521bb174473121b922cbebb983b628c191253d1e0e88b2d49:1,
      "utxo": ($internal/0):0.1 BTC,
    ],
  ],
  "outputs": [
    bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va:0.0499 BTC,
    ($internal/1):0.25 BTC,
  ]
];

$signed = psbt::sign($psbt, $sk);
$tx = psbt::extract(psbt::finalize($signed));
$tx_hex = hex($tx);
```