### PR TITLE
New `WshScript` data type for raw Script in `wsh()`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,9 @@ pub enum RuntimeError {
     #[error("Expected a string, not {}", ValErrFmt(.0))]
     NotString(Box<Value>),
 
+    #[error("Expected a WshScript, not {}", ValErrFmt(.0))]
+    NotWshScript(Box<Value>),
+
     #[error("Expected a single Xpub, not {0}")]
     NotSingleXpub(Box<miniscript::descriptor::DescriptorPublicKey>),
 

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -247,8 +247,8 @@ fn should_use_colon_syntax(elements: &[Value]) -> bool {
             // Otherwise, only if the LHS and RHS are of different types
             (
                 lhs @ (Bool(_) | Number(_) | Bytes(_) | Address(_) | PubKey(_) | SecKey(_)
-                | Policy(_) | Descriptor(_) | TapInfo(_) | Psbt(_) | WithProb(..)
-                | Network(_) | Symbol(_)),
+                | Policy(_) | Descriptor(_) | TapInfo(_) | WshScript(_) | Psbt(_)
+                | WithProb(..) | Network(_) | Symbol(_)),
                 rhs,
             ) => mem::discriminant(lhs) != mem::discriminant(rhs),
         }
@@ -264,7 +264,7 @@ fn colon_separator(elements: &[Value]) -> &str {
     match (&elements[0], &elements[1]) {
         (
             String(_) | PubKey(_) | SecKey(_) | Policy(_) | Script(_) | Descriptor(_) | TapInfo(_)
-            | Psbt(_),
+            | WshScript(_) | Psbt(_),
             _,
         ) => ": ",
         (_, Array(_)) => ": ",

--- a/src/stdlib/psbt.rs
+++ b/src/stdlib/psbt.rs
@@ -311,8 +311,8 @@ fn update_input(psbt_input: &mut psbt::Input, tags: Array) -> Result<()> {
             "unknown" => psbt_input.unknown = val.try_into()?,
             "non_witness_utxo" => psbt_input.non_witness_utxo = Some(val.try_into()?),
             "witness_utxo" | "utxo" => {
-                // If the UTXO was specified using a Descriptor or a TaprootSpendInfo, keep
-                // a copy of them around prior to converting them to a TxOut scriptPubKey
+                // If the UTXO was specified using a DescriptorTaprootSpendInfo/WshScript,
+                // also use them to populate the PSBT fields.
                 if let Value::Array(arr) = &val {
                     match arr.first() {
                         Some(Value::Descriptor(desc)) if descriptor.is_none() => {
@@ -320,6 +320,9 @@ fn update_input(psbt_input: &mut psbt::Input, tags: Array) -> Result<()> {
                         }
                         Some(Value::TapInfo(tap)) if tapinfo.is_none() => {
                             tapinfo = Some(tap.clone())
+                        }
+                        Some(Value::WshScript(wsh)) => {
+                            psbt_input.witness_script = Some(wsh.0.clone())
                         }
                         _ => {}
                     }


### PR DESCRIPTION
- `wsh(Script)` now returns a `WshScript` that retains the full original Script. (Previously is was directly returning the P2WSH scriptPubKey)

- `scriptPubKey(WshScript)` can be used to get the P2PWSH scriptPubKey. This is done automatically when `WshInfo` is used in an output.

- `explicitScript(WshScript)` can be used to get the full original Script (the witness script).

- Populate the PSBT's `witness_script` using the `WshScript`. This enables using `wsh(Script)` as the UTXO for `tx::sighash()` (which requires knowledge of the full `witness_script`), and puts it more in line with the use of `wsh(Miniscript)` descriptors.