### PR TITLE
Implement tx::with_witness()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -193,6 +193,9 @@ pub enum RuntimeError {
     #[error("sh() can only wrap wsh() or wpkh()")]
     InvalidShUse,
 
+    #[error("Transaction input #{0} does not exists")]
+    TxInputNotFound(usize),
+
     #[error("Script cannot be represented as an address: {}", .0.pretty(None))]
     NotAddressable(Box<bitcoin::ScriptBuf>),
 

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -49,6 +49,26 @@ impl Array {
             Ok(self)
         }
     }
+    // Parse an Array that either contains a list of index:value tuples mapping from
+    // element indexes to values, or a full list of all element values with no indexes.
+    // Returned as a list of index:value tuples in both cases.
+    pub fn mapped_or_all<T: FromValue>(
+        self,
+        expected_all_length: usize,
+    ) -> Result<Vec<(usize, T)>> {
+        if let Some(Value::Array(first_el)) = self.first() {
+            if let Some(Value::Number(_)) = first_el.first() {
+                // Provided as [ 0: $val0, 1: $val1, ... ]
+                return self.try_into();
+            }
+        }
+        // Provided as [ $val0, $val1, ... ]
+        ensure!(
+            self.len() == expected_all_length,
+            Error::InvalidLength(self.len(), expected_all_length)
+        );
+        Ok(Vec::<T>::try_from(self)?.into_iter().enumerate().collect())
+    }
 
     pub fn is_tagged_with(&self, tag: &str) -> bool {
         self.first().is_some_and(|el| match el {


### PR DESCRIPTION
For example:
```javascript
$tx_unsigned = tx [
  "input": af53f2762ca3fdee7c24a4de710d38e585ccabc7b86e35104b3f5c180a012eb7:0,
  "output": bcrt1q4sggfwqnj4ane33u9ps9egch47s26d4unvtvw2:0.0999 BTC,
];

$sk = cMzLdeGd5vEqxB8B6VFQoRopQ3sLAAvEzDAoQgvX54xwofSWj1fx;
$sighash = tx::sighash($tx_unsigned, 0, [ wpkh($sk):0.1 BTC ], SIGHASH_ALL);
$signature = ecdsa::sign($sk, $sighash) + SIGHASH_ALL;

$tx_signed = tx::with_witness($tx_unsigned, [
  0: [ $signature, pubkey($sk) ],
]);
```

([playground](https://min.sc/v0.3/#c=%24tx_unsigned%20%3D%20tx%20%5B%0A%20%20%22input%22%3A%20af53f2762ca3fdee7c24a4de710d38e585ccabc7b86e35104b3f5c180a012eb7%3A0%2C%0A%20%20%22output%22%3A%20bcrt1q4sggfwqnj4ane33u9ps9egch47s26d4unvtvw2%3A0.0999%20BTC%2C%0A%5D%3B%0A%0A%24sk%20%3D%20cMzLdeGd5vEqxB8B6VFQoRopQ3sLAAvEzDAoQgvX54xwofSWj1fx%3B%0A%24sighash%20%3D%20tx%3A%3Asighash%28%24tx_unsigned%2C%200%2C%20%5B%20wpkh%28%24sk%29%3A0.1%20BTC%20%5D%2C%20SIGHASH_ALL%29%3B%0A%24signature%20%3D%20ecdsa%3A%3Asign%28%24sk%2C%20%24sighash%29%20%2B%20SIGHASH_ALL%3B%0A%0A%24tx_signed%20%3D%20tx%3A%3Awith_witness%28%24tx_unsigned%2C%20%5B%0A%20%200%3A%20%5B%20%24signature%2C%20pubkey%28%24sk%29%20%5D%2C%0A%5D%29%3B))