### PR TITLE
Implement xNUMS() to make unique NUMS as a derivable Xpub

### DIFF
--- a/src/stdlib/btc.minsc
+++ b/src/stdlib/btc.minsc
@@ -14,7 +14,9 @@ DUST_AMOUNT=DUST_WSH; // also == DUST_TR
 // Uses the sha256 of G in DER encoding, as suggested by BIP 341: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
 // assert::eq(NUMS, pubkey(hash::sha256(0x0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8)));
 NUMS = pubkey(0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0);
-TR_UNSPENDABLE = NUMS; // the default for tr(), can be overridden in user-land code
+
+// A unique NUMS as a derivable Xpub, using the SHA256 of $seed as the chain code
+fn xNUMS($seed) = pubkey(0x043587cf000000000000000000 + hash::sha256($seed) + 0x02 + bytes(NUMS))/0;
 
 // Useful as a default with CTV
 PREVOUT_NONE = 0000000000000000000000000000000000000000000000000000000000000000:0;
@@ -26,6 +28,10 @@ ENABLE_RBF = 0xFFFFFFFD;
 // Taproot
 //
 
+// The default unspendable key for tr(), can be overridden in user-land code
+TR_UNSPENDABLE = NUMS;
+
+// Create the witness stack for a script-path spend
 fn tr::script_witness($tr, $script, $stack) = $stack + [ $script, tr::ctrl($tr, $script) ];
 
 //


### PR DESCRIPTION
Can be used to generate a unique `NUMS` for a specific contract and its parameters. The resulting key can be identified as a `NUMS` by anyone with knowledge of the contract parameters, but hides the fact that its a `NUMS` from the outside world.

For example:

```javascript
fn cosigner_with_expiry($user_xpub, $cosigner_xpub, $timeout) {
  $NUMS = xNUMS(bytes("cosigner_with_expiry:") + bytes($user_xpub) + bytes($cosigner_xpub));
  tr($NUMS/*, pk($user_xpub/*) && (pk($cosigner_xpub/*) || older($timeout)))
}

cosigner_with_expiry($alice, $charlie, 6 months)
```
[`(Open in playground)`](https://min.sc/v0.3/#c=fn%20cosigner_with_expiry%28%24user_xpub%2C%20%24cosigner_xpub%2C%20%24timeout%29%20%7B%0A%20%20%24NUMS%20%3D%20xNUMS%28bytes%28%22cosigner_with_expiry%3A%22%29%20%2B%20bytes%28%24user_xpub%29%20%2B%20bytes%28%24cosigner_xpub%29%29%3B%0A%20%20tr%28%24NUMS%2F*%2C%20pk%28%24user_xpub%2F*%29%20%26%26%20%28pk%28%24cosigner_xpub%2F*%29%20%7C%7C%20older%28%24timeout%29%29%29%0A%7D%0A%0Acosigner_with_expiry%28%24alice%2C%20%24charlie%2C%206%20months%29)
